### PR TITLE
fix: use comma as branch separator in parseRepositories

### DIFF
--- a/main.go
+++ b/main.go
@@ -1341,7 +1341,7 @@ func parseRepositories(repoStrings []string) ([]Repository, error) {
 			branchesStr := strings.TrimSpace(repoStr[colonIndex+1:])
 
 			if branchesStr != "" {
-				branchList := strings.Split(branchesStr, "|")
+				branchList := strings.Split(branchesStr, ",")
 				for _, branch := range branchList {
 					branch = strings.TrimSpace(branch)
 					if branch != "" {


### PR DESCRIPTION
## Summary

- Fixed `parseRepositories` in `main.go` to split branch lists using `,` instead of `|`
- This resolves `TestParseRepositoriesWithSlashes/Multiple_branches_with_slashes` and `TestParseRepositoriesWithSlashes/Complex_branch_names` which were failing on `main`

## What changed

The branch separator in `parseRepositories` was `|`, but the tests (and the documented input format) expect `,` as the delimiter. Inputs like `owner/repo:main,feat/rebrand-main,release/v2.0` were being treated as a single branch named `main,feat/rebrand-main,release/v2.0` instead of three separate branches.

**Root cause:** `strings.Split(branchesStr, "|")` → `strings.Split(branchesStr, ",")`

## Test plan

- [x] `TestParseRepositoriesWithSlashes/Multiple_branches_with_slashes` — passes
- [x] `TestParseRepositoriesWithSlashes/Complex_branch_names` — passes
- [x] All other subtests in `TestParseRepositoriesWithSlashes` — still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)