### PR TITLE
fix: adicionar created_at ao PRData e queries da tabela prs

### DIFF
--- a/internal/database/models.go
+++ b/internal/database/models.go
@@ -55,6 +55,7 @@ type PRData struct {
 	PRNumber              int       `json:"pr_number"`
 	Title                 string    `json:"title"`
 	Username              string    `json:"username"`
+	CreatedAt             time.Time `json:"created_at"`
 	MergedAt              time.Time `json:"merged_at"`
 	HasComments           bool      `json:"has_comments"`            // Se tem comentários (issue ou review)
 	HasIssueComments      bool      `json:"has_issue_comments"`      // Se tem issue comments
@@ -167,6 +168,7 @@ func FromGithubPR(pr *github.PullRequest, repoOwner, repoName string) *PRData {
 		PRNumber:              pr.GetNumber(),
 		Title:                 pr.GetTitle(),
 		Username:              pr.User.GetLogin(),
+		CreatedAt:             pr.CreatedAt.Time,
 		MergedAt:              pr.MergedAt.Time,
 		Additions:             pr.GetAdditions(),
 		Deletions:             pr.GetDeletions(),

--- a/internal/database/sqlite.go
+++ b/internal/database/sqlite.go
@@ -111,6 +111,7 @@ func (db *sqliteDatabase) createTables() error {
 		pr_number INTEGER NOT NULL,
 		title TEXT NOT NULL,
 		username TEXT NOT NULL,
+		created_at DATETIME NOT NULL,
 		merged_at DATETIME NOT NULL,
 		additions INTEGER DEFAULT 0,
 		deletions INTEGER DEFAULT 0,
@@ -220,10 +221,10 @@ func (db *sqliteDatabase) createTables() error {
 // GetPR busca um PR pelo repositório e número
 func (db *sqliteDatabase) GetPR(repoOwner, repoName string, prNumber int) (*PRData, error) {
 	query := `
-		SELECT id, repo_owner, repo_name, pr_number, title, username, merged_at,
+		SELECT id, repo_owner, repo_name, pr_number, title, username, created_at, merged_at,
 		       has_comments, has_issue_comments, has_review_comments, has_reviews, has_approved_reviews,
 		       comments_checked, issue_comments_checked, review_comments_checked, reviews_checked, cached_at
-		FROM prs 
+		FROM prs
 		WHERE repo_owner = ? AND repo_name = ? AND pr_number = ?`
 
 	row := db.db.QueryRow(query, repoOwner, repoName, prNumber)
@@ -236,6 +237,7 @@ func (db *sqliteDatabase) GetPR(repoOwner, repoName string, prNumber int) (*PRDa
 		&pr.PRNumber,
 		&pr.Title,
 		&pr.Username,
+		&pr.CreatedAt,
 		&pr.MergedAt,
 		&pr.HasComments,
 		&pr.HasIssueComments,
@@ -262,11 +264,11 @@ func (db *sqliteDatabase) GetPR(repoOwner, repoName string, prNumber int) (*PRDa
 // SavePR salva um PR no banco
 func (db *sqliteDatabase) SavePR(pr *PRData) error {
 	query := `
-		INSERT OR REPLACE INTO prs 
-		(repo_owner, repo_name, pr_number, title, username, merged_at, additions, deletions, changed_files,
+		INSERT OR REPLACE INTO prs
+		(repo_owner, repo_name, pr_number, title, username, created_at, merged_at, additions, deletions, changed_files,
 		 has_comments, has_issue_comments, has_review_comments, has_reviews, has_approved_reviews,
 		 comments_checked, issue_comments_checked, review_comments_checked, reviews_checked, cached_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
 
 	_, err := db.db.Exec(query,
 		pr.RepoOwner,
@@ -274,6 +276,7 @@ func (db *sqliteDatabase) SavePR(pr *PRData) error {
 		pr.PRNumber,
 		pr.Title,
 		pr.Username,
+		pr.CreatedAt,
 		pr.MergedAt,
 		pr.Additions,
 		pr.Deletions,
@@ -308,12 +311,12 @@ func (db *sqliteDatabase) MarkPRCommentsChecked(repoOwner, repoName string, prNu
 	// Se não existe, cria um registro básico
 	if existingPR == nil {
 		insertQuery := `
-			INSERT INTO prs 
-			(repo_owner, repo_name, pr_number, title, username, merged_at, cached_at)
-			VALUES (?, ?, ?, ?, ?, ?, ?)`
+			INSERT INTO prs
+			(repo_owner, repo_name, pr_number, title, username, created_at, merged_at, cached_at)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
 
 		now := time.Now()
-		_, err := db.db.Exec(insertQuery, repoOwner, repoName, prNumber, "", "", now, now)
+		_, err := db.db.Exec(insertQuery, repoOwner, repoName, prNumber, "", "", now, now, now)
 		if err != nil {
 			return fmt.Errorf("erro ao criar registro básico do PR: %v", err)
 		}
@@ -753,12 +756,12 @@ func (db *sqliteDatabase) MarkPRReviewsChecked(repoOwner, repoName string, prNum
 	// Se não existe, cria um registro básico
 	if existingPR == nil {
 		insertQuery := `
-			INSERT INTO prs 
-			(repo_owner, repo_name, pr_number, title, username, merged_at, cached_at)
-			VALUES (?, ?, ?, ?, ?, ?, ?)`
+			INSERT INTO prs
+			(repo_owner, repo_name, pr_number, title, username, created_at, merged_at, cached_at)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
 
 		now := time.Now()
-		_, err := db.db.Exec(insertQuery, repoOwner, repoName, prNumber, "", "", now, now)
+		_, err := db.db.Exec(insertQuery, repoOwner, repoName, prNumber, "", "", now, now, now)
 		if err != nil {
 			return fmt.Errorf("erro ao criar registro básico do PR: %v", err)
 		}
@@ -880,10 +883,10 @@ func (db *sqliteDatabase) GetReviewsByPR(repoOwner, repoName string, prNumber in
 // GetAllPRs busca todos os PRs salvos no banco
 func (db *sqliteDatabase) GetAllPRs() ([]*PRData, error) {
 	query := `
-		SELECT id, repo_owner, repo_name, pr_number, title, username, merged_at, additions, deletions, changed_files,
+		SELECT id, repo_owner, repo_name, pr_number, title, username, created_at, merged_at, additions, deletions, changed_files,
 		       has_comments, has_issue_comments, has_review_comments, has_reviews, has_approved_reviews,
 		       comments_checked, issue_comments_checked, review_comments_checked, reviews_checked, cached_at
-		FROM prs 
+		FROM prs
 		ORDER BY merged_at DESC`
 
 	rows, err := db.db.Query(query)
@@ -902,6 +905,7 @@ func (db *sqliteDatabase) GetAllPRs() ([]*PRData, error) {
 			&pr.PRNumber,
 			&pr.Title,
 			&pr.Username,
+			&pr.CreatedAt,
 			&pr.MergedAt,
 			&pr.Additions,
 			&pr.Deletions,
@@ -933,10 +937,10 @@ func (db *sqliteDatabase) GetAllPRs() ([]*PRData, error) {
 // GetAllPRsInDateRange busca PRs em um intervalo de datas específico
 func (db *sqliteDatabase) GetAllPRsInDateRange(startDate, endDate time.Time) ([]*PRData, error) {
 	query := `
-		SELECT id, repo_owner, repo_name, pr_number, title, username, merged_at, additions, deletions, changed_files,
+		SELECT id, repo_owner, repo_name, pr_number, title, username, created_at, merged_at, additions, deletions, changed_files,
 		       has_comments, has_issue_comments, has_review_comments, has_reviews, has_approved_reviews,
 		       comments_checked, issue_comments_checked, review_comments_checked, reviews_checked, cached_at
-		FROM prs 
+		FROM prs
 		WHERE merged_at >= ? AND merged_at <= ?
 		ORDER BY merged_at DESC`
 
@@ -956,6 +960,7 @@ func (db *sqliteDatabase) GetAllPRsInDateRange(startDate, endDate time.Time) ([]
 			&pr.PRNumber,
 			&pr.Title,
 			&pr.Username,
+			&pr.CreatedAt,
 			&pr.MergedAt,
 			&pr.Additions,
 			&pr.Deletions,


### PR DESCRIPTION
## Problema

O banco de dados (`comments.db`) continha `created_at DATETIME NOT NULL` na tabela `prs`, mas o campo estava ausente em:

- DDL de criação da tabela no código
- Struct `PRData`
- Todos os `INSERT` e `SELECT` da tabela `prs`

Isso causava uma violação de NOT NULL constraint ao chamar `MarkPRCommentsChecked` ou `MarkPRReviewsChecked` quando o PR não existia no cache e o código tentava criar um registro básico.

## Mudanças

- Adicionado `CreatedAt time.Time` ao struct `PRData` em `models.go`
- Adicionado `CreatedAt: pr.CreatedAt.Time` em `FromGithubPR`
- Adicionado `created_at DATETIME NOT NULL` ao DDL da tabela `prs`
- Atualizado `GetPR`, `SavePR`, `GetAllPRs` e `GetAllPRsInDateRange` para incluir `created_at` nas queries e nos Scans
- Atualizado os dois inserts básicos (`MarkPRCommentsChecked` e `MarkPRReviewsChecked`) para passar `created_at = now`

## Teste

- [ ] `go build ./...` passa sem erros
- [ ] Rodar o comando que disparava o erro e confirmar que não aparece mais "erro ao criar registro básico do PR"

🤖 Generated with [Claude Code](https://claude.com/claude-code)